### PR TITLE
Api update

### DIFF
--- a/fingrid json-kysely.yaml.txt
+++ b/fingrid json-kysely.yaml.txt
@@ -1,309 +1,171 @@
 # Fingrid application/json-kysely => configuration.yaml
-  # Tarvitset oman api-keyn lue ohjeet: https://data.fingrid.fi/fi/pages/api käytä saamaasi api-keytä kohdassa x-api-key: !secret fingrid_api_key
-  # Tässä käytettävät reaaliaikaiset (päivittyvät Fingridillä 3 minuutin välein) tietoaineistot löytyvät: https://data.fingrid.fi/fi/organization/fingrid
+  # Tarvitset oman api-keyn lue ohjeet: https://developer-data.fingrid.fi/ käytä saamaasi api-keytä kohdassa x-api-key: !secret fingrid_api_key
+  # Tässä käytettävät reaaliaikaiset (päivittyvät Fingridillä 3 tai 15 minuutin välein) tietoaineistot löytyvät: https://developer-data.fingrid.fi/api-details#api=avoindata-api&operation=GetDatasetShorts
   # Huom! Tuotantomuodoista ei vielä löydy Fingridin rajapinnasta reaaliaikaista Aurinkovoiman tuotantoa, tämä puuttuu tästä johdosta.
 
 rest:
-  - resource: https://api.fingrid.fi/v1/variable/event/json/192%2C193%2C194%2C209%2C58%2C185%2C178%2C196%2C182%2C191%2C202%2C188%2C201%2C189%2C205%2C181%2C89%2C90%2C194%2C180%2C195%2C187%2C87%2C183
+  - resource_template: >
+      {% set now_utc = utcnow() %}
+      {% set now_minus_90 = now_utc - timedelta(minutes=90) %}
+      {% set start_time = now_minus_90.strftime('%Y-%m-%dT%H:%M:%SZ') %}
+      https://data.fingrid.fi/api/data?datasets=60,61,90,55,75,183,57,188,74,124,194,58,201,202,205,209,191&startTime={{ start_time }}&pageSize=1000&sortBy=startTime    
     headers:
-      Accept: application/json
-      x-api-key: !secret fingrid_api_key
-    scan_interval: 600
-
+      x-api-key: !secret fingrid_api
+    scan_interval: 180
     sensor:
       - name: "Rajasiirto Pohjois-Ruotsi"
-        unique_id: fingrid_2
+        unique_id: fingrid_1
         icon: mdi:transmission-tower
+        json_attributes_path: $.data
         value_template: >-
-          {% set value_json = value_json | sort(attribute='variable_id') %}
-          {% if value_json[1].value < 0 %}
-          Tuonti {{ value_json[1].value | round(0) }} MW →
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 60) | map(attribute='value') | first %}
+          {% if value_json < 0 %}
+          Import {{ value_json | round(0) }} MW →
           {% else %}
-          ← Vienti {{ value_json[1].value | round(0) }} MW
+          ← Export {{ value_json | round(0) }} MW
           {% endif %}
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
 
       - name: "Rajasiirto Keski-Ruotsi"
-        unique_id: "fingrid_3"
-        icon: mdi:mdiTransmissionTowerImport
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %}
-          {% if value_json[2].value < 0 %}
-          Tuonti {{ value_json[2].value | round(0) }} MW →
+        unique_id: fingrid_2
+        icon: mdi:transmission-tower
+        json_attributes_path: $.data
+        value_template: >-
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 61) | map(attribute='value') | first %}
+          {% if value_json < 0 %}
+          Import {{ value_json | round(0) }} MW →
           {% else %}
-          ← Vienti {{ value_json[2].value | round(0) }} MW
+          ← Export {{ value_json | round(0) }} MW
           {% endif %}
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
 
       - name: "Rajasiirto Ahvenanmaa"
-        unique_id: "fingrid_4"
-        icon: mdi:mdiTransmissionTowerImport
+        unique_id: fingrid_3
+        icon: mdi:transmission-tower
+        json_attributes_path: $.data
         value_template: >-
-          {% set value_json = value_json | sort(attribute='variable_id') %}
-          {% if value_json[3].value < 0 %}
-          Tuonti {{ value_json[3].value | round(0) }} MW → 
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 90) | map(attribute='value') | first %}
+          {% if value_json < 0 %}
+          Import {{ value_json | round(0) }} MW →
           {% else %}
-          ← Vienti {{ value_json[3].value | round(0) }} MW
+          ← Export {{ value_json | round(0) }} MW
           {% endif %}
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
 
-      - name: "Helsinki"
-        unique_id: "fingrid_5"
-        icon: mdi:temperature-celsius
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %}
-          {{ value_json[4].value | round(1) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-          
       - name: "Rajasiirto Viroon"
-        unique_id: "fingrid_6"
+        unique_id: fingrid_4
         icon: mdi:transmission-tower
+        json_attributes_path: $.data
         value_template: >-
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {% if value_json[5].value < 0 %}
-          ↑ Tuonti {{ value_json[5].value | round(0) }} MW
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 55) | map(attribute='value') | first %}
+          {% if value_json < 0 %}
+          Import {{ value_json | round(0) }} MW →
           {% else %}
-          ↓ Vienti {{ value_json[5].value | round(0) }} MW
+          ← Export {{ value_json | round(0) }} MW
           {% endif %}
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-
-      - name: "Tuulivoima tuotanto"
-        unique_id: "fingrid_7"
-        icon: mdi:transmission-tower
-        value_template: >-
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[6].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-
-      - name: "Jyväskylä"
-        unique_id: "fingrid_8"
-        icon: mdi:temperature-celsius
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[7].value | round(1) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-
-      - name: "Tehoreservi"
-        unique_id: "fingrid_9"
-        icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[8].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-
-      - name: "Rovaniemi"
-        unique_id: "fingrid_10"
-        icon: mdi:temperature-celsius
-        value_template: >-
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[9].value | round(1)  }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
 
       - name: "Rajasiirto Norja"
-        unique_id: "fingrid_11"
+        unique_id: fingrid_5
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {% if value_json[10].value < 0 %}
-          Tuonti {{ value_json[10].value | round(0) }} MW ↓
+        json_attributes_path: $.data
+        value_template: >-
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 57) | map(attribute='value') | first %}
+          {% if value_json < 0 %}
+          Import {{ value_json | round(0) }} MW →
           {% else %}
-          ↑  Vienti {{ value_json[10].value | round(0) }} MW
+          ← Export {{ value_json | round(0) }} MW
           {% endif %}
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+
+      - name: "Rajasiirto Venäjä"
+        unique_id: fingrid_6
+        icon: mdi:transmission-tower
+        json_attributes_path: $.data
+        value_template: >-
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 58) | map(attribute='value') | first %}
+          {% if value_json < 0 %}
+          Import {{ value_json | round(0) }} MW →
+          {% else %}
+          ← Export {{ value_json | round(0) }} MW
+          {% endif %}
+
+      - name: "Tuulivoima tuotanto"
+        unique_id: fingrid_7
+        icon: mdi:transmission-tower
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 75) | map(attribute='value') | first }}"
+
+      - name: "Tehoreservi"
+        unique_id: fingrid_8
+        icon: mdi:transmission-tower
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 183) | map(attribute='value') | first }}"
 
       - name: "Ydinvoima"
-        unique_id: "fingrid_12"
+        unique_id: fingrid_9
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[11].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 188) | map(attribute='value') | first }}"
 
-      - name: "Lauhdevoimatuonta"
-        unique_id: "fingrid_13"
-        icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[12].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-
-      - name: "Vesivoima"
-        unique_id: "fingrid_14"
-        icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[13].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-          
       - name: "Tuotanto Suomessa"
-        unique_id: "fingrid_15"
+        unique_id: fingrid_10
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[14].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-          
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 74) | map(attribute='value') | first }}"
+
       - name: "Kulutus Suomessa"
-        unique_id: "fingrid_16"
+        unique_id: fingrid_11
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[15].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 124) | map(attribute='value') | first }}"
 
-      - name: "Tuonti- / vienti+ (netto)"
-        unique_id: "fingrid_17"
+      - name: "Tuonti vienti netto"
+        unique_id: fingrid_12
         icon: mdi:transmission-tower
-        value_template: >-
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[16].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-          
-      - name: "Rajasiirto Venäjä"
-        unique_id: "fingrid_18"
-        icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {% if value_json[17].value < 0 %}
-          ← Tuonti {{ value_json[17].value | round(0) }} MW 
-          {% else %}
-          Vienti {{ value_json[17].value | round(0) }} MW →
-          {% endif %} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-          
-      - name: "Oulu"
-        unique_id: "fingrid_19"
-        icon: mdi:temperature-celsius
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[18].value | round(1) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 194) | map(attribute='value') | first }}"
 
-      - name: "Yhteistuotanto (kaukolämpö)"
-        unique_id: "fingrid_20"
+      - name: "Yhteistuotanto kaukolämpö"
+        unique_id: fingrid_13
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[19].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 201) | map(attribute='value') | first }}"
 
-      - name: "Yhteistuotanto (teollisuus)"
-        unique_id: "fingrid_21"
+      - name: "Yhteistuotanto teollisuus"
+        unique_id: fingrid_14
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[20].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 202) | map(attribute='value') | first }}"
 
       - name: "Muu tuotanto"
-        unique_id: "fingrid_22"
+        unique_id: fingrid_15
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %} 
-          {{ value_json[21].value | round(0) }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 205) | map(attribute='value') | first }}"
 
-# Tässä mapper perustuu Perttu Pöyhtärin koodiin: https://github.com/iivana/home-assistant-fingrid-api/blob/main/fingrid-power-system-state.yaml
+      - name: "Vesivoima"
+        unique_id: fingrid_16
+        icon: mdi:transmission-tower
+        unit_of_measurement: 'MW'
+        json_attributes_path: $.data
+        value_template: "{{ value_json.data | selectattr('datasetId', 'eq', 191) | map(attribute='value') | first }}"
+
       - name: "Voimajärjestelmän käyttötilanne"
-        unique_id: "fingrid_23"
+        unique_id: fingrid_17
         icon: mdi:transmission-tower
-        value_template: >- 
-          {% set value_json = value_json | sort(attribute='variable_id') %}
+        json_attributes_path: $.data
+        value_template: >-
+          {% set value_json = value_json.data | selectattr('datasetId', 'eq', 209) | map(attribute='value') | first %}
           {% set mapper =  {
-            1 : 'Normaali',
-            2 : 'Heikentynyt',
-            3 : 'Vaarassa',
-            4 : 'Vakava häiriö',
-            5 : 'Vakava häiriö (palautus)' } %}
-          {% set state =  value_json[22].value %}
-          {{ mapper[state] if state in mapper else 'Ei tiedossa' }} 
-        json_attributes:
-          - "value"
-          - "variable_id"
-          - "start_time"
-          - "end_time"
-
+            1 : 'Normal',
+            2 : 'Degraded',
+            3 : 'At risk',
+            4 : 'Severe disturbance',
+            5 : 'Severe disturbance (reversal)' } %}
+          {% set state =  value_json %}
+          {{ mapper[state] if state in mapper else 'Not known' }}

--- a/fingrid json-kysely.yaml.txt
+++ b/fingrid json-kysely.yaml.txt
@@ -162,10 +162,10 @@ rest:
         value_template: >-
           {% set value_json = value_json.data | selectattr('datasetId', 'eq', 209) | map(attribute='value') | first %}
           {% set mapper =  {
-            1 : 'Normal',
-            2 : 'Degraded',
-            3 : 'At risk',
-            4 : 'Severe disturbance',
-            5 : 'Severe disturbance (reversal)' } %}
+            1 : 'Normaali',
+            2 : 'Heikentynyt',
+            3 : 'Vaarassa',
+            4 : 'Vakava häiriö',
+            5 : 'Vakava häiriö (palautus)' } %}
           {% set state =  value_json %}
-          {{ mapper[state] if state in mapper else 'Not known' }}
+          {{ mapper[state] if state in mapper else 'Ei tiedossa' }}


### PR DESCRIPTION
Päivitetty uuteen rajapintaan. Kyselyssä jätetty pois lämpötilatiedot eri paikkakunnilta. Tarvittaessa ne voi lisätä näillä datasetId-arvoilla;
Helsinki (id: 178), Jyväskylä (id: 182), Oulu (id: 196), Rovaniemi (id: 185).